### PR TITLE
Update bot.ts - sendMessage 方法中 guildId 为 undefined 时导致 channelId 拼接错误

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -63,8 +63,9 @@ export class IIROSE_Bot<C extends Context = Context, T extends IIROSE_Bot.Config
     {
       return [];
     }
-    const messages = await new IIROSE_BotMessageEncoder(this, `${channelId}:` + guildId, guildId, options).send(content);
-
+    const finalChannelId = guildId ? `${channelId}:${guildId}` : channelId;
+    const messages = await new IIROSE_BotMessageEncoder(this, finalChannelId, guildId, options).send(content);
+  
     return messages.map(message => message.id).filter(id => id !== undefined) as string[];
   }
 


### PR DESCRIPTION
## 🐛 问题修复

### 问题描述
当调用 `sendMessage()` 方法时，如果没有提供 `guildId` 参数（值为 `undefined`），当前实现会错误地将 `:undefined` 拼接到 channelId 后面，导致频道标识符格式错误。

**问题示例：**
- 输入：`channelId = "public:5fdcb9b634621"`，`guildId = undefined`
- 当前输出：`"public:5fdcb9b634621:undefined"`
- 期望输出：`"public:5fdcb9b634621"`

### 问题根源
在 `bot.ts` 文件第 71 行，代码无条件地拼接 `channelId` 和 `guildId`：
```typescript
new IIROSE_BotMessageEncoder(this, `${channelId}:` + guildId, guildId, options)
```
当 guildId 为 undefined 时，会导致 channelId + ":undefined" 的结果。

---

## 解决方案
添加条件判断，只有当 guildId 实际存在时才进行拼接：
```
const finalChannelId = guildId ? `${channelId}:${guildId}` : channelId;
new IIROSE_BotMessageEncoder(this, finalChannelId, guildId, options)
```

---

## 复现步骤

调用 bot.sendMessage('public:5fdcb9b634621', messageContent)
观察传递给 IIROSE_BotMessageEncoder 的 channelId
修复前：会得到 'public:5fdcb9b634621:undefined'
修复后：会得到 'public:5fdcb9b634621'
