### PR TITLE
fix: 修复 sendMessage 方法未返回正确消息ID的问题

### DIFF
--- a/src/ws.ts
+++ b/src/ws.ts
@@ -258,6 +258,25 @@ export class WsClient<C extends Context = Context> extends Adapter.WsClient<C, I
         message = Buffer.from(array).toString('utf8');
       }
 
+      const currentUsername = this.bot.config.smStart ? this.bot.config.smUsername : this.bot.config.usename;
+      
+      if (message.includes('>') && message.includes(currentUsername)) {
+        const messageIdMatch = message.match(/(\d{12,})$/);
+        if (messageIdMatch) {
+          const messageId = messageIdMatch[1];
+          
+          const userPattern = new RegExp(`>${currentUsername}>`, 'i');
+          if (userPattern.test(message)) {
+            if (this.bot.messageIdResolvers.length > 0) {
+              const resolver = this.bot.messageIdResolvers.shift();
+              if (resolver) {
+                resolver(messageId);
+              }
+            }
+          }
+        }
+      }
+
       if (!this.firstLogin)
       {
         this.firstLogin = true;


### PR DESCRIPTION
## 问题描述
修复了 `session.send()` 和 `bot.sendMessage()` 方法返回空数组 而非真实消息ID的问题。

## 问题根因
- **时序问题**：消息ID在WebSocket响应中异步返回，但sendMessage方法在消息ID到达前就已返回
- **缺少等待机制**：原代码没有等待WebSocket响应中的消息ID

## 解决方案
使用Promise机制等待WebSocket响应中的真实消息ID：

1. **在`bot.ts`中**：添加Promise机制，等待消息ID后再返回
2. **在`ws.ts`中**：捕获WebSocket响应中的消息ID并触发Promise resolve

## 修复效果对比

### 修复前
```javascript
const messageIds = await session.send("测试消息");
console.log(messageIds); // 输出: []
```
修复后
```javascript
const messageIds = await session.send("测试消息");
console.log(messageIds); // 输出: [ '809465121879' ]
```
测试验证
使用以下测试代码验证修复效果：
```javascript
ctx.middleware(async (session, next) => {
    if (session.platform === "iirose") {
        if (session.content === "nihao") {
            const messageIds = await session.send("nihao!");
            console.log(messageIds); // 现在正确返回: [ '809465121879' ]
        }
    }
    return next();
}, true);
```

---

- 提高与其他插件的兼容性
- 解决依赖消息ID的功能问题
- 无性能影响，仅增加Promise等待机制